### PR TITLE
Add DockerCompose

### DIFF
--- a/sensecap-controller-backend/Dockerfile
+++ b/sensecap-controller-backend/Dockerfile
@@ -1,5 +1,4 @@
 FROM balenalib/raspberrypi4-64-ubuntu-openjdk:11-bionic
-EXPOSE 8080:8080
 RUN mkdir /app
 COPY ./build/install/sensecap-controller-backend/ /app/
 WORKDIR /app/bin

--- a/sensecap-controller-backend/build.gradle.kts
+++ b/sensecap-controller-backend/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation("io.ktor:ktor-server-compression:$ktor_version")
     implementation("io.ktor:ktor-server-double-receive:$ktor_version")
     implementation("io.ktor:ktor-server-netty:$ktor_version")
-    implementation("io.ktor:ktor-server-http-redirect-jvm:$ktor_version")
     implementation("io.ktor:ktor-client-jetty:$ktor_version")
     implementation("io.ktor:ktor-client-serialization:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")

--- a/sensecap-controller-backend/docker-compose.yml
+++ b/sensecap-controller-backend/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  controller:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "80:8080"
+    restart: always

--- a/sensecap-controller-backend/src/main/kotlin/com/inframousriddles/plugins/Routing.kt
+++ b/sensecap-controller-backend/src/main/kotlin/com/inframousriddles/plugins/Routing.kt
@@ -5,20 +5,12 @@ import com.inframousriddles.sensecap.routes.SenseCAPRoutes
 import io.ktor.client.*
 import io.ktor.client.engine.jetty.*
 import io.ktor.server.routing.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 
 fun Application.configureRouting() {
     install(DoubleReceive)
-
-    install(HttpsRedirect) {
-        // The port to redirect to. By default, 443, the default HTTPS port.
-        sslPort = 443
-        // 301 Moved Permanently, or 302 Found redirect.
-        permanentRedirect = false
-    }
 
     val client = HttpClient(Jetty)
 


### PR DESCRIPTION
* In order to expose a port on Balena, we need to utilize DockerCompose to have a proper port mapping to our service.
